### PR TITLE
Add requiresMainQueueSetup

### DIFF
--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -5,6 +5,12 @@
 //#import <UIKit/UIKit.h>
 
 @implementation WifiManager
+  
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid


### PR DESCRIPTION
Without this, React Native issues a warning.