### PR TITLE
fix(Android): Guess network as WPA2 instead of returning an error

### DIFF
--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -205,9 +205,8 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
 			@SuppressLint("MissingPermission")
 			final WIFI_ENCRYPTION encryption = findEncryptionByScanning(SSID);
 			// FIXME: Weird that encryption being null means that the wifi network could not be found
-			if (encryption == null) {
-				promise.reject("notInRange", String.format("Not in range of the provided SSID: %s ", SSID));
-				return;
+			if (encryption == null) { // For recently created wifi networks, we guess it is WPA2
+				encryption = WIFI_ENCRYPTION.WPA2;
 			}
 			connectTo(SSID, password, encryption, promise);
 		}


### PR DESCRIPTION
I work with IoT devices and most of the time you want to connect to a recently created WiFi network. Since most of WiFi networks nowadays use WPA2, I think it is better to guess that than to return an error when it is not in the list of recently scanned networks.