### PR TITLE
Connect to SSID prefix functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,31 @@ The SSID of the wifi network to connect with.
 Type: `string`
 The password of the wifi network to connect with.
 
-#### isWeb
+#### isWep
 Type: `boolean`
-Used on iOS.
+Used on iOS. If YES, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
+
+#### Errors:
+* `notInRange`: The WIFI network is not currently in range.
+* `addOrUpdateFailed`: Could not add or update the network configuration.
+* `disconnectFailed`: Disconnecting from the network failed. This is done as part of the connect flow.
+* `connectNetworkFailed`: Could not connect to network.
+
+### connectToProtectedSSIDPrefix(SSIDPrefix: string, password: string, isWep: boolean): Promise
+
+Use this function when you want to match a known SSID prefix, but don’t have a full SSID. If the system finds multiple Wi-Fi networks whose SSID string matches the given prefix, it selects the network with the greatest signal strength.
+
+#### SSIDPrefix
+Type: `string`
+A prefix string to match the SSID of a Wi-Fi network.
+
+#### password
+Type: `string`
+The password of the wifi network to connect with.
+
+#### isWep
+Type: `boolean`
+Used on iOS. If YES, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
 
 #### Errors:
 * `notInRange`: The WIFI network is not currently in range.

--- a/README.md
+++ b/README.md
@@ -190,20 +190,22 @@ The following methods work only on iOS
 
 ###  `connectToSSID(ssid: string): Promise`
 
+###  `connectToSSIDPrefix(ssid: string): Promise`
+
 ### `disconnectFromSSID(ssid: string): Promise`
 
 ## Only Android
 The following methods work only on Android
 
-### `loadWifiList(successCallback: function, errorCallback: function)` 
+### `loadWifiList(successCallback: function, errorCallback: function)`
 
 Method to get a list of nearby WiFI networks.
-  
+
 #### successCallback( wifiList:  string )
 
 Type: `function`
 
-Function to be called if the attempt is successful. It contains a stringified JSONArray of wifiObjects as parameter, each object containing: 
+Function to be called if the attempt is successful. It contains a stringified JSONArray of wifiObjects as parameter, each object containing:
 
 * `SSID`: The network name.
 * `BSSID`: The WiFi BSSID.
@@ -218,7 +220,7 @@ Type: `function`
 
 Function to be called if any error occurs during the attempt. It contains a `string` as parameter with the error message.
 
-#### Usage 
+#### Usage
 
 ```javascript
 WifiManager.loadWifiList(
@@ -231,7 +233,7 @@ WifiManager.loadWifiList(
 	error =>  console.log(error)
 );
 /**
-Result: 
+Result:
 "Wifi 1 - Name of the network"
 "Wifi 2 - Name of the network"
 "Wifi 3 - Name of the network"
@@ -243,7 +245,7 @@ Result:
 
 This method is similar to `loadWifiList` but it forcefully starts the wifi scanning on android and in the callback fetches the list.
 
-#### Usage 
+#### Usage
 
 Same as `loadWifiList`.
 

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -56,7 +56,7 @@ RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
 
     if (@available(iOS 11.0, *)) {
         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid];
-        configuration.joinOnce = false;
+        configuration.joinOnce = true;
 
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
@@ -79,7 +79,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
 
     if (@available(iOS 13.0, *)) {
         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid passphrase:passphrase isWEP:isWEP];
-        configuration.joinOnce = false;
+        configuration.joinOnce = true;
 
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
@@ -102,7 +102,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
 
     if (@available(iOS 11.0, *)) {
         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:passphrase isWEP:isWEP];
-        configuration.joinOnce = false;
+        configuration.joinOnce = true;
 
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -32,7 +32,7 @@
 
 - (NSString *) getWifiSSID {
     NSString *kSSID = (NSString*) kCNNetworkInfoKeySSID;
-    
+
     NSArray *ifs = (__bridge_transfer id)CNCopySupportedInterfaces();
     for (NSString *ifnam in ifs) {
         NSDictionary *info = (__bridge_transfer id)CNCopyCurrentNetworkInfo((__bridge CFStringRef)ifnam);
@@ -53,11 +53,11 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (@available(iOS 11.0, *)) {
         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid];
-        configuration.joinOnce = true;
-        
+        configuration.joinOnce = false;
+
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
                 reject(@"nehotspot_error", @"Error while configuring WiFi", error);
@@ -65,9 +65,32 @@ RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
                 resolve(nil);
             }
         }];
-        
+
     } else {
         reject(@"ios_error", @"Not supported in iOS<11.0", nil);
+    }
+}
+
+RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
+                  withPassphrase:(NSString*)passphrase
+                  isWEP:(BOOL)isWEP
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+
+    if (@available(iOS 13.0, *)) {
+        NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid passphrase:passphrase isWEP:isWEP];
+        configuration.joinOnce = false;
+
+        [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
+            if (error != nil) {
+                reject(@"nehotspot_error", @"Error while configuring WiFi", error);
+            } else {
+                resolve(nil);
+            }
+        }];
+
+    } else {
+        reject(@"ios_error", @"Not supported in iOS<13.0", nil);
     }
 }
 
@@ -76,11 +99,11 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
                   isWEP:(BOOL)isWEP
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (@available(iOS 11.0, *)) {
         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:passphrase isWEP:isWEP];
-        configuration.joinOnce = true;
-        
+        configuration.joinOnce = false;
+
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
                 reject(@"nehotspot_error", @"Error while configuring WiFi", error);
@@ -88,16 +111,16 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
                 resolve(nil);
             }
         }];
-        
+
     } else {
-        reject(@"ios_error", @"Not supported in iOS<11.0", nil);
+        reject(@"ios_error", @"Not supported in iOS<13.0", nil);
     }
 }
 
 RCT_EXPORT_METHOD(disconnectFromSSID:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (@available(iOS 11.0, *)) {
         [[NEHotspotConfigurationManager sharedManager] getConfiguredSSIDsWithCompletionHandler:^(NSArray<NSString *> *ssids) {
             if (ssids != nil && [ssids indexOfObject:ssid] != NSNotFound) {
@@ -108,7 +131,7 @@ RCT_EXPORT_METHOD(disconnectFromSSID:(NSString*)ssid
     } else {
         reject(@"ios_error", @"Not supported in iOS<11.0", nil);
     }
-    
+
 }
 
 

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -71,6 +71,27 @@ RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
     }
 }
 
+RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
+                   resolver:(RCTPromiseResolveBlock)resolve
+                   rejecter:(RCTPromiseRejectBlock)reject) {
+
+     if (@available(iOS 13.0, *)) {
+         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid];
+         configuration.joinOnce = true;
+
+         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
+             if (error != nil) {
+                 reject(@"nehotspot_error", @"Error while configuring WiFi", error);
+             } else {
+                 resolve(nil);
+             }
+         }];
+
+     } else {
+         reject(@"ios_error", @"Not supported in iOS<13.0", nil);
+     }
+ }
+
 RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
                   withPassphrase:(NSString*)passphrase
                   isWEP:(BOOL)isWEP

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -113,7 +113,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
         }];
 
     } else {
-        reject(@"ios_error", @"Not supported in iOS<13.0", nil);
+        reject(@"ios_error", @"Not supported in iOS<11.0", nil);
     }
 }
 


### PR DESCRIPTION
iOS 13+ users can use connectToProtectedSSIDPrefix and connectToSSIDPrefix when they want to match a known SSID prefix, but don’t have a full SSID. If the device finds multiple Wi-Fi networks whose SSID string matches the given prefix, it selects the network with the greatest signal strength.

Added connectToProtectedSSIDPrefix and connectToSSIDPrefix to README, and fixed "isWeb" to "isWep" in documentation with detailed explanation.