### PR TITLE
fix(iOS): Fix joinOnce for connectToSSIDPrefix 

### DIFF
--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -62,7 +62,7 @@ RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
 
      if (@available(iOS 13.0, *)) {
          NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid];
-         configuration.joinOnce = true;
+         configuration.joinOnce = false;
 
          [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
              if (error != nil) {


### PR DESCRIPTION
Implemented joinOnce for connectToSSIDPrefix, this is to match the already merged PR changes in `connectToProtectedSSID` and https://github.com/JuanSeBestia/react-native-wifi-reborn/pull/33