### PR TITLE
isRemoveWifiNetwork use callback instead of Promise

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -86,7 +86,7 @@ declare module 'react-native-wifi-reborn' {
 
     export function disconnect(): void;
 
-    export function isRemoveWifiNetwork(SSID: string): Promise<void>;
+    export function isRemoveWifiNetwork(SSID: string, callback: (isRemoveNetworkCalled: boolean) => void): void
 
     export enum FORCE_WIFI_USAGE_ERRORS {
         couldNotGetConnectivityManager = 'couldNotGetConnectivityManager',


### PR DESCRIPTION
the type of isRemoveWifiNetwork should be using callback instead of Promise
And the boolean args of the callback actually just indicate if the network with SSID is in the configured network and the removeNetwork() has been called.