### PR TITLE
fix: Add null type to password on connectToProtectedSSID

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -27,7 +27,7 @@ declare module 'react-native-wifi-reborn' {
      */
     export function connectToProtectedSSID(
         SSID: string,
-        password: string,
+        password: string|null,
         isWEP: boolean
     ): Promise<void>;
 


### PR DESCRIPTION
Solve typescript type checking issue for the function `connectToProtectedSSID `