### PR TITLE
fix(iOS): Consistent joinOnce=false configuration

### DIFF
--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -85,7 +85,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
 
     if (@available(iOS 13.0, *)) {
         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid passphrase:passphrase isWEP:isWEP];
-        configuration.joinOnce = true;
+        configuration.joinOnce = false;
 
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
@@ -116,7 +116,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
             configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:passphrase isWEP:isWEP];
         }
         configuration.joinOnce = false;
-        
+
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
                 reject(@"nehotspot_error", [error localizedDescription], error);
@@ -156,7 +156,7 @@ RCT_EXPORT_METHOD(disconnectFromSSID:(NSString*)ssid
 RCT_REMAP_METHOD(getCurrentWifiSSID,
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (@available(iOS 13, *)) {
         // Reject when permission had rejected
         if([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied){
@@ -168,7 +168,7 @@ RCT_REMAP_METHOD(getCurrentWifiSSID,
             reject(@"cannot_detect_ssid", @"Cannot detect SSID because LocationPermission is Restricted", nil);
         }
     }
-    
+
     BOOL hasLocationPermission = [CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedWhenInUse ||
     [CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedAlways;
     if (@available(iOS 13, *) && hasLocationPermission == NO) {


### PR DESCRIPTION
This setting in the `connectToProtectedSSIDPrefix` was inconsistent with the other functions for no reason. It was already discussed why it should be set to `false`. https://github.com/JuanSeBestia/react-native-wifi-reborn/issues/2


However, in my opinion we should let the user of this module decide the values for `joinOnce` and `lifeTimeinDays`. If we all agree on that it should be done in another PR.

https://developer.apple.com/documentation/networkextension/nehotspotconfiguration