### PR TITLE
fix: Fix Android 10 no-internet support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ build/
 .gradle
 local.properties
 *.iml
+android/.settings/
+.project
 
 # BUCK
 buck-out/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,6 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
-    implementation 'com.thanosfisherman.wifiutils:wifiutils:1.5.1'
+    implementation 'com.thanosfisherman.wifiutils:wifiutils:1.5.0'
 }
   

--- a/example/RNWifiReborn/.gitignore
+++ b/example/RNWifiReborn/.gitignore
@@ -28,6 +28,7 @@ build/
 .gradle
 local.properties
 *.iml
+android/.settings/
 
 # node.js
 #


### PR DESCRIPTION
Go back to WifiUtils 1.5.0 who called `connectivityManager.bindProcessToNetwork(network);`.
Without it isn't possible to do api calls or have internet access.