### PR TITLE
Android 10 forceWiFiUsage & Reconnection 

### DIFF
--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -95,7 +95,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void forceWifiUsage(final boolean useWifi, final Promise promise) {
-        this(useWifi, false, promise);
+        forceWifiUsage(useWifi, false, promise);
     }
     
     /**
@@ -121,7 +121,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
         }
 
         if (useWifi) {
-            NetworkRequest networkRequest = new NetworkRequest.Builder();
+            NetworkRequest.Builder networkRequest = new NetworkRequest.Builder();
             
             networkRequest.addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
             
@@ -129,9 +129,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
                 networkRequest.removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
             }
 
-            networkRequest.build();
-
-            connectivityManager.requestNetwork(networkRequest, new ConnectivityManager.NetworkCallback() {
+            connectivityManager.requestNetwork(networkRequest.build(), new ConnectivityManager.NetworkCallback() {
                 @Override
                 public void onAvailable(@NonNull final Network network) {
                     super.onAvailable(network);

--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -94,8 +94,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
      * @param useWifi boolean to force wifi off or on
      */
     @ReactMethod
-    public void forceWifiUsage(final boolean useWifi, final Promise promise)
-    {
+    public void forceWifiUsage(final boolean useWifi, final Promise promise) {
         this(useWifi, false, promise);
     }
     

--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -95,7 +95,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void forceWifiUsage(final boolean useWifi, final Promise promise) {
-        forceWifiUsage(useWifi, false, promise);
+        forceWifiUsageWithInternet(useWifi, false, promise);
     }
     
     /**
@@ -111,7 +111,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
      * @param hasInternet boolean to remove the internet capabilitiy to prevent mobile data routing
      */
     @ReactMethod
-    public void forceWifiUsage(final boolean useWifi, final boolean hasInternet, final Promise promise) {
+    public void forceWifiUsageWithInternet(final boolean useWifi, final boolean hasInternet, final Promise promise) {
         final ConnectivityManager connectivityManager = (ConnectivityManager) context
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
 
@@ -325,6 +325,19 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
                 promise.resolve(false);
             }
         });
+
+        // final List<WifiConfiguration> mWifiConfigList = wifi.getConfiguredNetworks();
+        // final String comparableSSID = ('"' + SSID + '"'); //Add quotes because wifiConfig.SSID has them
+
+        // for (WifiConfiguration wifiConfig : mWifiConfigList) {
+        //     if (wifiConfig.SSID.equals(comparableSSID)) {
+        //         promise.resolve(wifi.removeNetwork(wifiConfig.networkId));
+        //         wifi.saveConfiguration();
+        //         return;
+        //     }
+        // }
+
+        // promise.resolve(true);
     }
 
     /**


### PR DESCRIPTION
The following changes allow for a smooth setup of an IoT device that broadcasts as an AP without internet.  Android 10 routes the traffic to the mobile data network even if the transport type is set to WiFi.  Additionally Android 10 doesn't save the configuration of the WiFi network so the existing isRemoveWiFiNetwork leaves the phone in an unconnected state until the user visit the WiFi Setting page for the OS.

• Updated forceWiFiUsage to include hasInternet parameter, overloaded function to default parameter to false for backward compatibility
• Removed NET_CAPABILITY_INTERNET if hasInternet is false to prevent traffic from routing to mobile data network
• Converted isRemoveWifiNetwork to use WifiUtils library.  This will disconnect and remove the configuration if supported. Android 10 configuration is not saved, only disconnect will occur