### PR TITLE
feat(Android): Add forceWifiUsageWithOptions & add noInternet option

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,11 +297,17 @@ If you are connected to that network, it will disconnect.
 * `locationPermissionMissing`: Starting android 6, location permission needs to be granted for wifi 
 
 ### `forceWifiUsage(useWifi: boolean): Promise`
+Deprecated; see forceWifiUsageWithOptions.
 
- Use this to execute api calls to a wifi network that does not have internet access.
- Useful for commissioning IoT devices.
- This will route all app network requests to the network (instead of the mobile connection).
- It is important to disable it again after using as even when the app disconnects from the wifi network it will keep on routing everything to wifi.
+### `forceWifiUsageWithOptions(useWifi: boolean, options<Record<string, unknown>)
+
+Use this to execute api calls to a wifi network that does not have internet access.
+Useful for commissioning IoT devices.
+This will route all app network requests to the network (instead of the mobile connection).
+It is important to disable it again after using as even when the app disconnects from the wifi network it will keep on routing everything to wifi.
+
+#### options
+* `noInternet: Boolean`: Indicate the wifi network does not have internet connectivity.
 
 ## Conventions
 

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -226,17 +226,23 @@ declare module 'react-native-wifi-reborn' {
     }
 
     /**
-     * Use this to execute api calls to a wifi network that does not have internet access.
-     *
-     * Useful for commissioning IoT devices.
-     *
-     * This will route all app network requests to the network (instead of the mobile connection).
+     * @deprecated Use forceWifiUsageWithOptions.
+     */
+    export function forceWifiUsage(useWifi: boolean): Promise<void>;
+
+    /**
+     * Use this to route all app network requests to the wifi network (instead of the mobile connection).
      * It is important to disable it again after using as even when the app disconnects from the wifi
      * network it will keep on routing everything to wifi.
      *
-     * @param useWifi boolean to force wifi off or on
+     * Useful for commissioning IoT devices. If the wifi access point has no internet you can indicate so with
+     * the option `noInternet`.
+     *
+     * @param useWifi Force wifi usage on or off.
+     * @param options `noInternet` To indicate the access point has no internet. Usefull as some
+     * phone vendor customizations will switch back to mobile when the wifi access point has no internet.
      */
-    export function forceWifiUsage(useWifi: boolean): Promise<void>;
+    export function forceWifiUsageWithOptions(useWifi: boolean, options: { noInternet: boolean });
 
     //#endregion
 }


### PR DESCRIPTION
Removes NET_CAPABILITY_INTERNET when indicated via noInternet so android phones with intelligent wifi switching are less eager to switch to a different wifi network.

Inspiration from: https://github.com/JuanSeBestia/react-native-wifi-reborn/pull/109 🎉.