### PR TITLE
fix(Android): Fix WifiUtils dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,6 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
-    implementation 'com.thanosfisherman.wifiutils:wifiutils:1.6.3'
+    implementation 'com.thanosfisherman.wifiutils:wifiutils:1.6.4'
 }
   

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip


### PR DESCRIPTION
Dependency WifiUtils 1.6.3 had some issues with their dependencies. They've released a new version to fix this.