### PR TITLE
chore(Android): Move mappers and receivers

### DIFF
--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -27,8 +27,8 @@ import com.facebook.react.bridge.WritableArray;
 import com.reactlibrary.rnwifi.errors.IsRemoveWifiNetworkErrorCodes;
 import com.reactlibrary.rnwifi.errors.LoadWifiListErrorCodes;
 import com.reactlibrary.rnwifi.receivers.WifiScanResultReceiver;
-import com.reactlibrary.utils.LocationUtils;
-import com.reactlibrary.utils.PermissionUtils;
+import com.reactlibrary.rnwifi.utils.LocationUtils;
+import com.reactlibrary.rnwifi.utils.PermissionUtils;
 import com.thanosfisherman.wifiutils.WifiUtils;
 import com.thanosfisherman.wifiutils.wifiConnect.ConnectionErrorCode;
 import com.thanosfisherman.wifiutils.wifiConnect.ConnectionSuccessListener;
@@ -39,7 +39,7 @@ import com.thanosfisherman.wifiutils.wifiRemove.RemoveSuccessListener;
 
 import java.util.List;
 
-import static com.reactlibrary.mappers.WifiScanResultsMapper.mapWifiScanResults;
+import static com.reactlibrary.rnwifi.mappers.WifiScanResultsMapper.mapWifiScanResults;
 
 public class RNWifiModule extends ReactContextBaseJavaModule {
     private final WifiManager wifi;

--- a/android/src/main/java/com/reactlibrary/rnwifi/mappers/WifiScanResultsMapper.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/mappers/WifiScanResultsMapper.java
@@ -1,4 +1,4 @@
-package com.reactlibrary.mappers;
+package com.reactlibrary.rnwifi.mappers;
 
 import android.net.wifi.ScanResult;
 

--- a/android/src/main/java/com/reactlibrary/rnwifi/receivers/WifiScanResultReceiver.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/receivers/WifiScanResultReceiver.java
@@ -13,7 +13,7 @@ import com.facebook.react.bridge.WritableArray;
 
 import java.util.List;
 
-import static com.reactlibrary.mappers.WifiScanResultsMapper.mapWifiScanResults;
+import static com.reactlibrary.rnwifi.mappers.WifiScanResultsMapper.mapWifiScanResults;
 
 public class WifiScanResultReceiver extends BroadcastReceiver {
     private final WifiManager wifiManager;

--- a/android/src/main/java/com/reactlibrary/rnwifi/utils/LocationUtils.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/utils/LocationUtils.java
@@ -1,4 +1,4 @@
-package com.reactlibrary.utils;
+package com.reactlibrary.rnwifi.utils;
 
 import android.annotation.TargetApi;
 import android.content.ContentResolver;

--- a/android/src/main/java/com/reactlibrary/rnwifi/utils/PermissionUtils.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/utils/PermissionUtils.java
@@ -1,4 +1,4 @@
-package com.reactlibrary.utils;
+package com.reactlibrary.rnwifi.utils;
 
 import android.Manifest;
 import android.annotation.TargetApi;


### PR DESCRIPTION
The mappers and receivers are not in the com.reactlibrary.rnwifi package.