### PR TITLE
fix(Android): getCurrentWifiSSID return null if '<unknown ssid>'

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ Used on iOS. If true, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 pe
 
 ### `getCurrentWifiSSID(): Promise`
 
+Returns the SSID of the current WiFi network.
+
+#### Errors:
+ * `CouldNotDetectSSID`: Not connected or connecting.
+
 ## Only iOS
 
 The following methods work only on iOS

--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -24,6 +24,7 @@ import com.reactlibrary.rnwifi.errors.ConnectErrorCodes;
 import com.reactlibrary.rnwifi.errors.DisconnectErrorCodes;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
+import com.reactlibrary.rnwifi.errors.GetCurrentWifiSSIDErrorCodes;
 import com.reactlibrary.rnwifi.errors.IsRemoveWifiNetworkErrorCodes;
 import com.reactlibrary.rnwifi.errors.LoadWifiListErrorCodes;
 import com.reactlibrary.rnwifi.receivers.WifiScanResultReceiver;
@@ -306,7 +307,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
 
         // Android returns `<unknown ssid>` when it is not connected or still connecting
         if (ssid.equals("<unknown ssid>")) {
-            promise.resolve(null);
+            promise.reject(GetCurrentWifiSSIDErrorCodes.CouldNotDetectSSID.toString(), "Not connected or connecting.");
             return;
         }
 

--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -304,6 +304,12 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
             ssid = ssid.substring(1, ssid.length() - 1);
         }
 
+        // Android returns `<unknown ssid>` when it is not connected or still connecting
+        if (ssid.equals("<unknown ssid>")) {
+            promise.resolve(null);
+            return;
+        }
+
         promise.resolve(ssid);
     }
 

--- a/android/src/main/java/com/reactlibrary/rnwifi/errors/GetCurrentWifiSSIDErrorCodes.kt
+++ b/android/src/main/java/com/reactlibrary/rnwifi/errors/GetCurrentWifiSSIDErrorCodes.kt
@@ -1,0 +1,8 @@
+package com.reactlibrary.rnwifi.errors
+
+enum class GetCurrentWifiSSIDErrorCodes {
+    /**
+     * Not connected or connecting.
+     */
+    CouldNotDetectSSID,
+}

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -102,7 +102,10 @@ declare module 'react-native-wifi-reborn' {
         isWEP: boolean
     ): Promise<void>;
 
-    export function getCurrentWifiSSID(): Promise<string>;
+    /**
+     * Returns the name of the currently connected WiFi or null when not connected.
+     */
+    export function getCurrentWifiSSID(): Promise<string | null>;
 
     //#region iOS only
 

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -102,10 +102,14 @@ declare module 'react-native-wifi-reborn' {
         isWEP: boolean
     ): Promise<void>;
 
+    export enum GET_CURRENT_WIFI_SSID_ERRRORS {
+        CouldNotDetectSSID = 'CouldNotDetectSSID',
+    }
+
     /**
-     * Returns the name of the currently connected WiFi or null when not connected.
+     * Returns the name of the currently connected WiFi. When not connected, the promise will be or null when not connected.
      */
-    export function getCurrentWifiSSID(): Promise<string | null>;
+    export function getCurrentWifiSSID(): Promise<string>;
 
     //#region iOS only
 


### PR DESCRIPTION
Sometimes while switching network, android returns <unknown ssid>.
You aren't connected, so let's simply return an empty string.