### PR TITLE
Updated manual linking path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This library is correctly autolinked on React Native 60+ 🎉.
 
 1. Open up `android/app/src/main/java/[...]/MainActivity.java`
 
-- Add `import com.reactlibrary.RNWifiPackage;` to the imports at the top of the file
+- Add `import com.reactlibrary.rnwifi.RNWifiModule;` to the imports at the top of the file
 - Add `new RNWifiPackage()` to the list returned by the `getPackages()` method
 
 2. Append the following lines to `android/settings.gradle`:


### PR DESCRIPTION
I think the manual linking docs are outadated.