### PR TITLE
fix(Android): Add elvis dependency to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
 
     implementation 'com.thanosfisherman.wifiutils:wifiutils:1.6.4'
+    implementation 'com.thanosfisherman.elvis:elvis:3.0'
 }
   


### PR DESCRIPTION
To fix the dependency bug reported here: https://github.com/JuanSeBestia/react-native-wifi-reborn/issues/142  we can add 'com.thanosfisherman.elvis:elvis:3.0' in the libs build.gradle for now.

I'll follow up with WifiUtils. On some devices there are no problems (Samsung S10) and on others there are (OnePlus NORD) so I think it might be cpu architecture related.

Fixes #142 