### PR TITLE
fix(Android): Replace Kotlin files with Java

### DIFF
--- a/android/src/main/java/com/reactlibrary/rnwifi/errors/GetCurrentWifiSSIDErrorCodes.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/errors/GetCurrentWifiSSIDErrorCodes.java
@@ -1,0 +1,8 @@
+package com.reactlibrary.rnwifi.errors;
+
+public enum GetCurrentWifiSSIDErrorCodes {
+    /**
+     * Not connected or connecting.
+     */
+    CouldNotDetectSSID,
+}

--- a/android/src/main/java/com/reactlibrary/rnwifi/errors/GetCurrentWifiSSIDErrorCodes.kt
+++ b/android/src/main/java/com/reactlibrary/rnwifi/errors/GetCurrentWifiSSIDErrorCodes.kt
@@ -1,8 +1,0 @@
-package com.reactlibrary.rnwifi.errors
-
-enum class GetCurrentWifiSSIDErrorCodes {
-    /**
-     * Not connected or connecting.
-     */
-    CouldNotDetectSSID,
-}


### PR DESCRIPTION
As reported here; https://github.com/JuanSeBestia/react-native-wifi-reborn/issues/153, mixing kotlin with java breaks building apps. Let's stick to using Java for now.