### PR TITLE
fix(iOS): reject after connecting to WiFi with SSID-prefix

### DIFF
--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -93,7 +93,12 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
             if (error != nil) {
                 reject([self parseError:error], @"Error while configuring WiFi", error);
             } else {
-                resolve(nil);
+                // Verify SSID connection
+                if ([ssid isEqualToString:[self getWifiSSID]]){
+                    resolve(nil);
+                } else {
+                    reject([ConnectError code:UnableToConnect], [NSString stringWithFormat:@"%@/%@", @"Unable to connect to Wi-Fi with prefix ", ssid], nil);
+                }
             }
         }];
 


### PR DESCRIPTION
Closes #182

I tested the proposed idea (similar to what is done when connecting to a protected network with the full SSID, verify the connection after connecting only with a prefix provided) I had from looking at the source code and could confirm that this indeed fixes the issue of `connectToProtectedSSIDPrefix` not rejecting when the connection was not successful. The system alert does still appear, but the method properly rejects.

I tested this change with an app on my iPhone with iOS 14.4. Are there any additional tests/steps I should perform?

Thanks for your support!