### PR TITLE
feat(iOS): allow joinOnce property to be set for iOS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,17 @@ Used on iOS. If true, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 pe
 
 #### joinOnce
 Type: `boolean`
-Used on iOS. When joinOnce is set to true, the hotspot remains configured and connected only as long as the app that configured it is running in the foreground. The hotspot is disconnected and its configuration is removed when any of the following events occurs:
+Used on iOS. Optional param. Defaults to `false`. When joinOnce is set to true, the hotspot remains configured and connected only as long as the app that configured it is running in the foreground. The hotspot is disconnected and its configuration is removed when any of the following events occurs:
+
+* The app stays in the background for more than 15 seconds.
+
+* The device sleeps.
+
+* The app crashes, quits, or is uninstalled.
+
+* The app connects the device to a different Wi-Fi network.
+
+* The user connects the device to a different Wi-Fi network.
 
 #### Errors:
 * iOS:
@@ -216,7 +226,7 @@ Used on iOS. If YES, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 per
 
 #### joinOnce
 Type: `boolean`
-Used on iOS. When joinOnce is set to true, the hotspot remains configured and connected only as long as the app that configured it is running in the foreground. The hotspot is disconnected and its configuration is removed when any of the following events occurs:
+Used on iOS. Optional param. Defaults to `false`. When joinOnce is set to true, the hotspot remains configured and connected only as long as the app that configured it is running in the foreground. The hotspot is disconnected and its configuration is removed when any of the following events occurs:
 
 * The app stays in the background for more than 15 seconds.
 
@@ -227,9 +237,6 @@ Used on iOS. When joinOnce is set to true, the hotspot remains configured and co
 * The app connects the device to a different Wi-Fi network.
 
 * The user connects the device to a different Wi-Fi network.
-
-To disconnect the device from a hotspot configured with joinOnce set to true, call `disconnectFromSSID(ssid: string)`.
-
 
 #### Errors:
 * `unavailableForOSVersion`: Starting from iOS 11, NEHotspotConfigurationError is available.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,13 @@ The following methods work only on iOS
 
 ###  `connectToSSID(ssid: string): Promise`
 
+###  `connectToSSID(ssid: string, joinOnce: boolean): Promise`
+
+### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, joinOnce: boolean): Promise`
+
 ###  `connectToSSIDPrefix(ssid: string): Promise`
+
+###  `connectToSSIDPrefix(ssid: string, joinOnce: boolean): Promise`
 
 ### `disconnectFromSSID(ssid: string): Promise`
 
@@ -209,6 +215,22 @@ The password of the wifi network to connect with.
 #### isWep
 Type: `boolean`
 Used on iOS. If YES, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
+
+#### joinOnce
+Type: `boolean`
+Used on iOS. When joinOnce is set to true, the hotspot remains configured and connected only as long as the app that configured it is running in the foreground. The hotspot is disconnected and its configuration is removed when any of the following events occurs:
+
+* The app stays in the background for more than 15 seconds.
+
+* The device sleeps.
+
+* The app crashes, quits, or is uninstalled.
+
+* The app connects the device to a different Wi-Fi network.
+
+* The user connects the device to a different Wi-Fi network.
+
+To disconnect the device from a hotspot configured with joinOnce set to true, call `disconnectFromSSID(ssid: string)`.
 
 
 #### Errors:

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ _The api documentation is in progress._
 
 The following methods work on both Android and iOS
 
-### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean): Promise`
+### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, joinOnce?: boolean): Promise`
 
 Returns a promise that resolves when connected or rejects with the error when it couldn't connect to the wifi network.
 
@@ -153,6 +153,10 @@ The password of the wifi network to connect with.
 #### isWep
 Type: `boolean`
 Used on iOS. If true, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
+
+#### joinOnce
+Type: `boolean`
+Used on iOS. When joinOnce is set to true, the hotspot remains configured and connected only as long as the app that configured it is running in the foreground. The hotspot is disconnected and its configuration is removed when any of the following events occurs:
 
 #### Errors:
 * iOS:
@@ -188,19 +192,13 @@ Returns the SSID of the current WiFi network.
 
 The following methods work only on iOS
 
-###  `connectToSSID(ssid: string): Promise`
+###  `connectToSSID(ssid: string, joinOnce?: boolean): Promise`
 
-###  `connectToSSID(ssid: string, joinOnce: boolean): Promise`
-
-### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, joinOnce: boolean): Promise`
-
-###  `connectToSSIDPrefix(ssid: string): Promise`
-
-###  `connectToSSIDPrefix(ssid: string, joinOnce: boolean): Promise`
+###  `connectToSSIDPrefix(ssid: string, joinOnce?: boolean): Promise`
 
 ### `disconnectFromSSID(ssid: string): Promise`
 
-### `connectToProtectedSSIDPrefix(SSIDPrefix: string, password: string, isWep: boolean): Promise`
+### `connectToProtectedSSIDPrefix(SSIDPrefix: string, password: string, isWep: boolean, joinOnce?: boolean): Promise`
 
 Use this function when you want to match a known SSID prefix, but don’t have a full SSID. If the system finds multiple Wi-Fi networks whose SSID string matches the given prefix, it selects the network with the greatest signal strength.
 

--- a/README.md
+++ b/README.md
@@ -188,15 +188,15 @@ Returns the SSID of the current WiFi network.
 
 The following methods work only on iOS
 
-###  `connectToSSID(ssid: string, joinOnce?: boolean): Promise`
+###  `connectToSSID(ssid: string): Promise`
 
-###  `connectToSSIDPrefix(ssid: string, joinOnce?: boolean): Promise`
+###  `connectToSSIDPrefix(ssid: string): Promise`
 
 ### `disconnectFromSSID(ssid: string): Promise`
 
-### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, joinOnce?: boolean): Promise`
+### `connectToProtectedSSIDOnce(SSID: string, password: string, isWEP: boolean, joinOnce: boolean): Promise`
 
-### `connectToProtectedSSIDPrefix(SSIDPrefix: string, password: string, isWep: boolean, joinOnce?: boolean): Promise`
+### `connectToProtectedSSIDPrefix(SSIDPrefix: string, password: string, isWep: boolean): Promise`
 
 Use this function when you want to match a known SSID prefix, but don’t have a full SSID. If the system finds multiple Wi-Fi networks whose SSID string matches the given prefix, it selects the network with the greatest signal strength.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ _The api documentation is in progress._
 
 The following methods work on both Android and iOS
 
-### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, joinOnce?: boolean): Promise`
+### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean): Promise`
 
 Returns a promise that resolves when connected or rejects with the error when it couldn't connect to the wifi network.
 
@@ -153,20 +153,6 @@ The password of the wifi network to connect with.
 #### isWep
 Type: `boolean`
 Used on iOS. If true, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
-
-#### joinOnce
-Type: `boolean`
-Used on iOS. Optional param. Defaults to `false`. When joinOnce is set to true, the hotspot remains configured and connected only as long as the app that configured it is running in the foreground. The hotspot is disconnected and its configuration is removed when any of the following events occurs:
-
-* The app stays in the background for more than 15 seconds.
-
-* The device sleeps.
-
-* The app crashes, quits, or is uninstalled.
-
-* The app connects the device to a different Wi-Fi network.
-
-* The user connects the device to a different Wi-Fi network.
 
 #### Errors:
 * iOS:
@@ -207,6 +193,8 @@ The following methods work only on iOS
 ###  `connectToSSIDPrefix(ssid: string, joinOnce?: boolean): Promise`
 
 ### `disconnectFromSSID(ssid: string): Promise`
+
+### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, joinOnce?: boolean): Promise`
 
 ### `connectToProtectedSSIDPrefix(SSIDPrefix: string, password: string, isWep: boolean, joinOnce?: boolean): Promise`
 

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -61,10 +61,17 @@ RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
 RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
                    resolver:(RCTPromiseResolveBlock)resolve
                    rejecter:(RCTPromiseRejectBlock)reject) {
+    [self connectToSSIDPrefix:ssid joinOnce:false resolver:resolve rejecter:reject];
+ }
+
+RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
+                   joinOnce:(BOOL)joinOnce
+                   resolver:(RCTPromiseResolveBlock)resolve
+                   rejecter:(RCTPromiseRejectBlock)reject) {
 
      if (@available(iOS 13.0, *)) {
          NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid];
-         configuration.joinOnce = false;
+         configuration.joinOnce = joinOnce;
 
          [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
              if (error != nil) {
@@ -85,9 +92,19 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
 
+    [self connectToProtectedSSIDPrefix:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
+                  withPassphrase:(NSString*)passphrase
+                  isWEP:(BOOL)isWEP
+                  joinOnce:(BOOL)joinOnce
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+
     if (@available(iOS 13.0, *)) {
         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid passphrase:passphrase isWEP:isWEP];
-        configuration.joinOnce = false;
+        configuration.joinOnce = joinOnce;
 
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
@@ -112,6 +129,15 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
                   isWEP:(BOOL)isWEP
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
+        [self connectToProtectedSSID:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
+                  withPassphrase:(NSString*)passphrase
+                  isWEP:(BOOL)isWEP
+                  joinOnce:(BOOL)joinOnce
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
     // Prevent NEHotspotConfigurationManager error when connecting to an already connected network
     if ([ssid isEqualToString:[self getWifiSSID]]) resolve(nil);
     if (@available(iOS 11.0, *)) {
@@ -122,7 +148,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
         } else {
             configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:passphrase isWEP:isWEP];
         }
-        configuration.joinOnce = false;
+        configuration.joinOnce = joinOnce;
 
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -55,7 +55,14 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false resolver:resolve rejecter:reject];
+    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false joinOnce:false resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
+                  joinOnce:(BOOL)joinOnce
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false joinOnce:joinOnce resolver:resolve rejecter:reject];
 }
 
 RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -55,30 +55,16 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false joinOnce:false resolver:resolve rejecter:reject];
-}
-
-RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
-                  joinOnce:(BOOL)joinOnce
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false joinOnce:joinOnce resolver:resolve rejecter:reject];
+    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false resolver:resolve rejecter:reject];
 }
 
 RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
-                   resolver:(RCTPromiseResolveBlock)resolve
-                   rejecter:(RCTPromiseRejectBlock)reject) {
-    [self connectToSSIDPrefix:ssid joinOnce:false resolver:resolve rejecter:reject];
- }
-
-RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
-                   joinOnce:(BOOL)joinOnce
                    resolver:(RCTPromiseResolveBlock)resolve
                    rejecter:(RCTPromiseRejectBlock)reject) {
 
      if (@available(iOS 13.0, *)) {
          NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid];
-         configuration.joinOnce = joinOnce;
+         configuration.joinOnce = false;
 
          [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
              if (error != nil) {
@@ -99,19 +85,9 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
 
-    [self connectToProtectedSSIDPrefix:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
-}
-
-RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
-                  withPassphrase:(NSString*)passphrase
-                  isWEP:(BOOL)isWEP
-                  joinOnce:(BOOL)joinOnce
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-
     if (@available(iOS 13.0, *)) {
         NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid passphrase:passphrase isWEP:isWEP];
-        configuration.joinOnce = joinOnce;
+        configuration.joinOnce = false;
 
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
@@ -136,10 +112,10 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
                   isWEP:(BOOL)isWEP
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-        [self connectToProtectedSSID:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
+    [self connectToProtectedSSIDOnce:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
 }
 
-RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
+RCT_EXPORT_METHOD(connectToProtectedSSIDOnce:(NSString*)ssid
                   withPassphrase:(NSString*)passphrase
                   isWEP:(BOOL)isWEP
                   joinOnce:(BOOL)joinOnce
@@ -147,6 +123,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
                   rejecter:(RCTPromiseRejectBlock)reject) {
     // Prevent NEHotspotConfigurationManager error when connecting to an already connected network
     if ([ssid isEqualToString:[self getWifiSSID]]) resolve(nil);
+    
     if (@available(iOS 11.0, *)) {
         NEHotspotConfiguration* configuration;
         // Check if open network

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -95,26 +95,13 @@ declare module 'react-native-wifi-reborn' {
      * @param SSID Wifi name.
      * @param password `null` for open networks.
      * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
-     */
-    export function connectToProtectedSSID(
-        SSID: string,
-        password: string | null,
-        isWEP: boolean
-    ): Promise<void>;
-
-    /**
-     * Connects to a WiFi network. Rejects with an error if it couldn't connect.
-     *
-     * @param SSID Wifi name.
-     * @param password `null` for open networks.
-     * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
      * @param joinOnce Used on iOS. If `true`, restricts the lifetime of a configuration to the operating status of the app that created it.
      */
     export function connectToProtectedSSID(
         SSID: string,
         password: string | null,
         isWEP: boolean,
-        joinOnce: boolean
+        joinOnce?: boolean
     ): Promise<void>;
 
     export enum GET_CURRENT_WIFI_SSID_ERRRORS {
@@ -129,19 +116,13 @@ declare module 'react-native-wifi-reborn' {
     //#region iOS only
 
     export function connectToSSID(SSID: string): Promise<void>;
-    export function connectToSSIDPrefix(SSIDPrefix: string): Promise<void>;
-    export function connectToSSIDPrefix(SSIDPrefix: string, joinOnce: boolean): Promise<void>;
+    export function connectToSSIDPrefix(SSIDPrefix: string, joinOnce?: boolean): Promise<void>;
     export function disconnectFromSSID(SSIDPrefix: string): Promise<void>;
     export function connectToProtectedSSIDPrefix(
         SSIDPrefix: string,
         password: string,
-        isWEP: boolean
-    ): Promise<void>;
-    export function connectToProtectedSSIDPrefix(
-        SSIDPrefix: string,
-        password: string,
         isWEP: boolean,
-        joinOnce: boolean
+        joinOnce?: boolean
     ): Promise<void>;
 
     //#endregion

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -95,13 +95,11 @@ declare module 'react-native-wifi-reborn' {
      * @param SSID Wifi name.
      * @param password `null` for open networks.
      * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
-     * @param joinOnce Used on iOS. If `true`, restricts the lifetime of a configuration to the operating status of the app that created it.
      */
     export function connectToProtectedSSID(
         SSID: string,
         password: string | null,
-        isWEP: boolean,
-        joinOnce?: boolean
+        isWEP: boolean
     ): Promise<void>;
 
     export enum GET_CURRENT_WIFI_SSID_ERRRORS {
@@ -118,6 +116,20 @@ declare module 'react-native-wifi-reborn' {
     export function connectToSSID(SSID: string, joinOnce?: boolean): Promise<void>;
     export function connectToSSIDPrefix(SSIDPrefix: string, joinOnce?: boolean): Promise<void>;
     export function disconnectFromSSID(SSIDPrefix: string): Promise<void>;
+    /**
+     * Connects to a WiFi network. Rejects with an error if it couldn't connect.
+     *
+     * @param SSID Wifi name.
+     * @param password `null` for open networks.
+     * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
+     * @param joinOnce Used on iOS. If `true`, restricts the lifetime of a configuration to the operating status of the app that created it.
+     */
+    export function connectToProtectedSSID(
+        SSID: string,
+        password: string | null,
+        isWEP: boolean,
+        joinOnce?: boolean
+    ): Promise<void>;
     export function connectToProtectedSSIDPrefix(
         SSIDPrefix: string,
         password: string,

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -102,6 +102,21 @@ declare module 'react-native-wifi-reborn' {
         isWEP: boolean
     ): Promise<void>;
 
+    /**
+     * Connects to a WiFi network. Rejects with an error if it couldn't connect.
+     *
+     * @param SSID Wifi name.
+     * @param password `null` for open networks.
+     * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
+     * @param joinOnce Used on iOS. If `true`, restricts the lifetime of a configuration to the operating status of the app that created it.
+     */
+    export function connectToProtectedSSID(
+        SSID: string,
+        password: string | null,
+        isWEP: boolean,
+        joinOnce: boolean
+    ): Promise<void>;
+
     export enum GET_CURRENT_WIFI_SSID_ERRRORS {
         CouldNotDetectSSID = 'CouldNotDetectSSID',
     }
@@ -115,11 +130,18 @@ declare module 'react-native-wifi-reborn' {
 
     export function connectToSSID(SSID: string): Promise<void>;
     export function connectToSSIDPrefix(SSIDPrefix: string): Promise<void>;
+    export function connectToSSIDPrefix(SSIDPrefix: string, joinOnce: boolean): Promise<void>;
     export function disconnectFromSSID(SSIDPrefix: string): Promise<void>;
     export function connectToProtectedSSIDPrefix(
         SSIDPrefix: string,
         password: string,
         isWEP: boolean
+    ): Promise<void>;
+    export function connectToProtectedSSIDPrefix(
+        SSIDPrefix: string,
+        password: string,
+        isWEP: boolean,
+        joinOnce: boolean
     ): Promise<void>;
 
     //#endregion

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -113,8 +113,8 @@ declare module 'react-native-wifi-reborn' {
 
     //#region iOS only
 
-    export function connectToSSID(SSID: string, joinOnce?: boolean): Promise<void>;
-    export function connectToSSIDPrefix(SSIDPrefix: string, joinOnce?: boolean): Promise<void>;
+    export function connectToSSID(SSID: string): Promise<void>;
+    export function connectToSSIDPrefix(SSIDPrefix: string): Promise<void>;
     export function disconnectFromSSID(SSIDPrefix: string): Promise<void>;
     /**
      * Connects to a WiFi network. Rejects with an error if it couldn't connect.
@@ -124,17 +124,16 @@ declare module 'react-native-wifi-reborn' {
      * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
      * @param joinOnce Used on iOS. If `true`, restricts the lifetime of a configuration to the operating status of the app that created it.
      */
-    export function connectToProtectedSSID(
+    export function connectToProtectedSSIDOnce(
         SSID: string,
         password: string | null,
         isWEP: boolean,
-        joinOnce?: boolean
+        joinOnce: boolean
     ): Promise<void>;
     export function connectToProtectedSSIDPrefix(
         SSIDPrefix: string,
         password: string,
-        isWEP: boolean,
-        joinOnce?: boolean
+        isWEP: boolean
     ): Promise<void>;
 
     //#endregion

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -115,7 +115,7 @@ declare module 'react-native-wifi-reborn' {
 
     //#region iOS only
 
-    export function connectToSSID(SSID: string): Promise<void>;
+    export function connectToSSID(SSID: string, joinOnce?: boolean): Promise<void>;
     export function connectToSSIDPrefix(SSIDPrefix: string, joinOnce?: boolean): Promise<void>;
     export function disconnectFromSSID(SSIDPrefix: string): Promise<void>;
     export function connectToProtectedSSIDPrefix(


### PR DESCRIPTION
## Summary

Exposes the option to set `joinOnce` on iOS methods. Documentation is verbatim from Apple's page https://developer.apple.com/documentation/networkextension/nehotspotconfiguration/2887518-joinonce.

I made an effort to ensure backwards compatibility with the previous functions by overloading them and re-using the implementations.

Please let me know if I totally messed this up or need to do any additional steps. I've been using this package for a while but this is my first time contributing. Thank you @JuanSeBestia & others for your great work!

## Related PRs
https://github.com/JuanSeBestia/react-native-wifi-reborn/pull/72 added `joinOnce=false` and mentioned adding this feature.