### PR TITLE
Fixed disconnectFromSSID not rejecting on error

### DIFF
--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -150,8 +150,10 @@ RCT_EXPORT_METHOD(disconnectFromSSID:(NSString*)ssid
         [[NEHotspotConfigurationManager sharedManager] getConfiguredSSIDsWithCompletionHandler:^(NSArray<NSString *> *ssids) {
             if (ssids != nil && [ssids indexOfObject:ssid] != NSNotFound) {
                 [[NEHotspotConfigurationManager sharedManager] removeConfigurationForSSID:ssid];
+                resolve(nil);
+            } else {
+                reject([ConnectError code:InvalidSSID], @"Invalid SSID or SSID not configured by app", nil);
             }
-            resolve(nil);
         }];
     } else {
         reject([ConnectError code:UnavailableForOSVersion], @"Not supported in iOS<11.0", nil);


### PR DESCRIPTION
This addresses the common issue on iOS where disconnecting from a wifi will seem to succeed despite failing:
https://github.com/JuanSeBestia/react-native-wifi-reborn/issues/17

Rejecting allows the consuming apps to handle the user experience better.

This is an alternative to https://github.com/JuanSeBestia/react-native-wifi-reborn/pull/214