### PR TITLE
fix(iOS): Fix disconnectFromSSID having no effect

### DIFF
--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -147,12 +147,7 @@ RCT_EXPORT_METHOD(disconnectFromSSID:(NSString*)ssid
                   rejecter:(RCTPromiseRejectBlock)reject) {
 
     if (@available(iOS 11.0, *)) {
-        [[NEHotspotConfigurationManager sharedManager] getConfiguredSSIDsWithCompletionHandler:^(NSArray<NSString *> *ssids) {
-            if (ssids != nil && [ssids indexOfObject:ssid] != NSNotFound) {
-                [[NEHotspotConfigurationManager sharedManager] removeConfigurationForSSID:ssid];
-            }
-            resolve(nil);
-        }];
+        [[NEHotspotConfigurationManager sharedManager] removeConfigurationForSSID:ssid];
     } else {
         reject([ConnectError code:UnavailableForOSVersion], @"Not supported in iOS<11.0", nil);
     }


### PR DESCRIPTION
Fixes https://github.com/JuanSeBestia/react-native-wifi-reborn/issues/17

I tested locally for iOS 15 on a wifi network that the app configured and calling disconnect directly works. But with the `getConfiguredSSIDsWithCompletionHandler` it does not.

This is an alternative to: https://github.com/JuanSeBestia/react-native-wifi-reborn/pull/213

