### PR TITLE
fix(Android): Replace jCenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -41,7 +41,5 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
-    implementation 'com.thanosfisherman.wifiutils:wifiutils:1.6.4'
-    implementation 'com.thanosfisherman.elvis:elvis:3.0'
+    implementation 'io.github.thanosfisherman.wifiutils:wifiutils:1.6.6'
 }
-  


### PR DESCRIPTION
jCenter is shutting down (https://blog.gradle.org/jcenter-shutdown). Android dependency WifiUtils is now published on mavenCentral 👏 so it's time to switch! React-native 65 also makes the switch to mavenCentral (https://github.com/facebook/react-native/releases/tag/v0.65.0).

* replace jCenter repository with mavenCentral
* change WifiUtils artifact id name to `io.github.thanosfisherman.wifiutils` and bump dependency to 1.6.6 (https://github.com/ThanosFisherman/WifiUtils/releases/tag/WifiUtils1.6.6)
* remove peer dependency Elvis (no longer required: https://github.com/ThanosFisherman/WifiUtils/releases/tag/WifiUtils1.6.4)
