### PR TITLE
fix(iOS): Revert wrong removal of promise resolution

### DIFF
--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -158,6 +158,7 @@ RCT_EXPORT_METHOD(disconnectFromSSID:(NSString*)ssid
 
     if (@available(iOS 11.0, *)) {
         [[NEHotspotConfigurationManager sharedManager] removeConfigurationForSSID:ssid];
+        resolve(nil);
     } else {
         reject([ConnectError code:UnavailableForOSVersion], @"Not supported in iOS<11.0", nil);
     }


### PR DESCRIPTION
In https://github.com/JuanSeBestia/react-native-wifi-reborn/pull/214 a bug was fixed regarding `disconnectFromSSID` having no effect. However, I'm pretty sure the `resolve(nil)` was wrongly removed. In our code, the promise now never resolves.

This PR reverts that unwanted deletion and makes sure the (JS) promise resolves.

Tested with our code.