### PR TITLE
fix: Use enum types instead of const in the TypeScript declaration file

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -190,7 +190,7 @@ declare module 'react-native-wifi-reborn' {
      */
     export function connectionStatus(): Promise<boolean>;
 
-    export const DISCONNECT_ERRORS = {
+    export enum DISCONNECT_ERRORS {
         /**
          * Could not get the WifiManager.
          * https://developer.android.com/reference/android/net/wifi/WifiManager?hl=en
@@ -201,7 +201,7 @@ declare module 'react-native-wifi-reborn' {
          * https://developer.android.com/reference/android/net/ConnectivityManager?hl=en
          */
         couldNotGetConnectivityManager = 'couldNotGetConnectivityManager',
-    };
+    }
 
     export function disconnect(): Promise<boolean>;
 
@@ -225,14 +225,14 @@ declare module 'react-native-wifi-reborn' {
      */
     export function getIP(): Promise<string>;
 
-    export const IS_REMOVE_WIFI_NETWORK_ERRORS = {
+    export enum IS_REMOVE_WIFI_NETWORK_ERRORS {
         /**
          * Starting android 6, location permission needs to be granted for wifi scanning.
          */
         locationPermissionMissing = 'locationPermissionMissing',
         couldNotGetWifiManager = 'couldNotGetWifiManager',
         couldNotGetConnectivityManager = 'couldNotGetConnectivityManager',
-    };
+    }
 
     /**
      * This method will remove the wifi network configuration.


### PR DESCRIPTION
When running `npx tsc` on my project, with `skipLibCheck` set to `false` in our `tsconfig.json` (which is the default anyway). The following TS errors were reported:

![Screenshot 2022-01-10 at 15 33 51](https://user-images.githubusercontent.com/135126/148784253-ccb3c5d3-6da0-4022-beb1-dfe82eb42391.png)
![Screenshot 2022-01-10 at 15 33 57](https://user-images.githubusercontent.com/135126/148784261-9e7e2633-7b61-4a23-bae5-1c681b2d219d.png)

This PR fixes these two issues by exposing `DISCONNECT_ERRORS` and `IS_REMOVE_WIFI_NETWORK_ERRORS` as proper `enum` types.