### PR TITLE
Android Tooling

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         minSdkVersion safeExtGet(minSdkVersion, 21)
         targetSdkVersion safeExtGet(targetSdkVersion, 31)
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:7.1.3'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ repositories {
         url "$projectDir/../node_modules/react-native/android"
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,8 @@
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
     repositories {
         google()
@@ -13,8 +17,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.3'
+    compileSdkVersion safeExtGet(compileSdkVersion, 31)
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -22,8 +25,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion safeExtGet(minSdkVersion, 21)
+        targetSdkVersion safeExtGet(targetSdkVersion, 31)
         versionCode 1
         versionName "1.0"
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 11 07:37:41 CEST 2020
+#Mon Sep 05 19:12:21 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
* replace jCenter with mavenCentral
* bump android gradle plugin
* bump gradle-wrapper
* use safeExtGet to get min, compile & sdk versions from app