### PR TITLE
feat(Android): added feature to connect to hidden wifi on android 10

### DIFF
--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -205,10 +205,11 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
      * @param SSID     name of the network to connect with
      * @param password password of the network to connect with
      * @param isWep    only for iOS
+     * @param isHidden only for android, use if WiFi is hidden
      * @param promise  to send success/error feedback
      */
     @ReactMethod
-    public void connectToProtectedSSID(@NonNull final String SSID, @NonNull final String password, final boolean isWep, final Promise promise) {
+    public void connectToProtectedSSID(@NonNull final String SSID, @NonNull final String password, final boolean isWep, final boolean isHidden, final Promise promise) {
         final boolean locationPermissionGranted = PermissionUtils.isLocationPermissionGranted(context);
         if (!locationPermissionGranted) {
             promise.reject(ConnectErrorCodes.locationPermissionMissing.toString(), "Location permission (ACCESS_FINE_LOCATION) is not granted");
@@ -228,7 +229,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
 
 
         this.removeWifiNetwork(SSID, promise, () -> {
-            connectToWifiDirectly(SSID, password, promise);
+            connectToWifiDirectly(SSID, password, isHidden, promise);
         });
     }
 
@@ -398,9 +399,9 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
         wifi.startScan();
     }
 
-    private void connectToWifiDirectly(@NonNull final String SSID, @NonNull final String password, final Promise promise) {
+    private void connectToWifiDirectly(@NonNull final String SSID, @NonNull final String password, final boolean isHidden, final Promise promise) {
         if (isAndroidTenOrLater()) {
-            connectAndroidQ(SSID, password, promise);
+            connectAndroidQ(SSID, password, isHidden, promise);
         } else {
             connectPreAndroidQ(SSID, password, promise);
         }
@@ -437,8 +438,9 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
-    private void connectAndroidQ(@NonNull final String SSID, @NonNull final String password, final Promise promise) {
+    private void connectAndroidQ(@NonNull final String SSID, @NonNull final String password, final boolean isHidden, final Promise promise) {
         WifiNetworkSpecifier.Builder wifiNetworkSpecifier = new WifiNetworkSpecifier.Builder()
+                .setIsHiddenSsid(isHidden)
                 .setSsid(SSID);
 
         if (!isNullOrEmpty(password)) {

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -95,11 +95,13 @@ declare module 'react-native-wifi-reborn' {
      * @param SSID Wifi name.
      * @param password `null` for open networks.
      * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
+     * @param isHidden only for android, use if WiFi is hidden
      */
     export function connectToProtectedSSID(
         SSID: string,
         password: string | null,
-        isWEP: boolean
+        isWEP: boolean,
+        isHidden: boolean
     ): Promise<void>;
 
     export enum GET_CURRENT_WIFI_SSID_ERRRORS {


### PR DESCRIPTION
I was using react-native-wifi-reborn for a project that needed the feature to connect to a device with a hidden WiFi. With these changes, I was able to connect to the device using `WifiManager.connectToProtectedSSID` (with Android 10+).