### PR TITLE
feat(android): 🌟 add support for React Native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "com.reactlibrary.rnwifi"
+
     compileSdkVersion safeExtGet(compileSdkVersion, 31)
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary.rnwifi">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />


### PR DESCRIPTION
feat(android): 🌟 add support for React Native 0.73 by removing the package from AndroidManifest and adding as build.gradle android namespace.

See https://twitter.com/thymikee/status/1670719044394053640?t=9IWMjn6I7i0lOdIZ5F7bHw&s=19