### PR TITLE
fix(Android): Open the Wifi settings panel on Android 10 and above.

### DIFF
--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -186,7 +186,22 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void setEnabled(final boolean enabled) {
-        wifi.setWifiEnabled(enabled);
+        if (isAndroidTenOrLater()) {
+            openWifiSettings();
+        } else {
+            wifi.setWifiEnabled(enabled);
+        }
+    }
+
+    /**
+     * Use this to open a wifi settings panel.
+     * For Android Q and above.
+     */
+    @ReactMethod
+    public void openWifiSettings() {
+        Intent intent = new Intent(Settings.Panel.ACTION_WIFI);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        this.context.startActivity(intent);
     }
 
     /**


### PR DESCRIPTION
The `setEnabled()` function is deprecated on Android 10 and above, and it appears not to work on Android 13.

The recommended solution is to utilize the `Settings.Panel.ACTION_WIFI` on these versions.