### PR TITLE
ANDROID: Timeout parameter on connectToProtectedSSID method

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The plugin provides props for extra customization. Every time you change the pro
 ```javascript
 import WifiManager from "react-native-wifi-reborn";
 
-WifiManager.connectToProtectedSSID(ssid, password, isWep, timeout).then(
+WifiManager.connectToProtectedWifiSSID(ssid, password, isWep).then(
   () => {
     console.log("Connected successfully!");
   },
@@ -171,7 +171,18 @@ _The api documentation is in progress._
 
 The following methods work on both Android and iOS
 
-### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, isHidden: boolean, timeout: number): Promise`
+### ```### NEW VERSION WITH OPTIONAL PARAMETERS ###``` 
+```
+connectToProtectedWifiSSID({
+      ssid: string;
+      password: string;
+      isWEP?: boolean;
+      isHidden?: boolean;
+      timeout?: number
+  ;}): Promise
+```
+
+### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, isHidden: boolean): Promise`
 
 Returns a promise that resolves when connected or rejects with the error when it couldn't connect to the wifi network.
 
@@ -197,9 +208,9 @@ Used on iOS. If true, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 pe
 Type: `boolean`
 Used on Android. If true, the network is a hidden Wi-Fi network.
 
-#### timeout
+#### timeout - ```ONLY NEW VERSION```
 TypeL `number`
-Used to set a timeout in seconds. Default 15 seconds.
+Used on Android to set a timeout in seconds. Default 15 seconds.
 
 #### Errors:
 * iOS:
@@ -220,7 +231,7 @@ Used to set a timeout in seconds. Default 15 seconds.
   * `didNotFindNetwork`: If the wifi network is not in range, the security type is unknown and WifiUtils doesn't support connecting to the network.
   * `authenticationErrorOccurred`: Authentication error occurred while trying to connect. The password could be incorrect or the user could have a saved network configuration with a different password!
   * `android10ImmediatelyDroppedConnection` : Firmware bugs on OnePlus prevent it from connecting on some firmware versions. More info: https://github.com/ThanosFisherman/WifiUtils/issues/63.
-  * `timeoutOccurred`: Could not connect in the timeout window.
+  * `timeoutOccurred`: Could not connect in the timeout window. - ```ONLY NEW VERSION```
 * Both:
   * `unableToConnect`: When an unknown error occurred.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The plugin provides props for extra customization. Every time you change the pro
 ```javascript
 import WifiManager from "react-native-wifi-reborn";
 
-WifiManager.connectToProtectedSSID(ssid, password, isWep).then(
+WifiManager.connectToProtectedSSID(ssid, password, isWep, timeout).then(
   () => {
     console.log("Connected successfully!");
   },
@@ -171,7 +171,7 @@ _The api documentation is in progress._
 
 The following methods work on both Android and iOS
 
-### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, isHidden: boolean): Promise`
+### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, isHidden: boolean, timeout: number): Promise`
 
 Returns a promise that resolves when connected or rejects with the error when it couldn't connect to the wifi network.
 
@@ -196,6 +196,10 @@ Used on iOS. If true, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 pe
 
 Type: `boolean`
 Used on Android. If true, the network is a hidden Wi-Fi network.
+
+#### timeout
+TypeL `number`
+Used to set a timeout in seconds. Default 15 seconds.
 
 #### Errors:
 * iOS:

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The following methods work on both Android and iOS
 ```
 connectToProtectedWifiSSID({
       ssid: string;
-      password: string;
+      password: string | null;
       isWEP?: boolean;
       isHidden?: boolean;
       timeout?: number

--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -479,7 +479,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
        
         final Handler timeoutHandler = new Handler(Looper.getMainLooper());
         final Runnable timeoutRunnable = () -> {
-            promise.reject("TimeoutError", "Connection timeout");
+            promise.reject(ConnectErrorCodes.timeoutOccurred.toString(), "Connection timeout");
             DisconnectCallbackHolder.getInstance().unbindProcessFromNetwork();
             DisconnectCallbackHolder.getInstance().disconnect();
         };

--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -268,7 +268,6 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
 
         this.removeWifiNetwork(ssid, promise, () -> {
             assert ssid != null;
-            assert password != null;
             connectToWifiDirectly(ssid, password, isHidden, secondsTimeout, promise);
         });
     }

--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -505,7 +505,13 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
                 super.onUnavailable();
                 timeoutHandler.removeCallbacks(timeoutRunnable);
                 promise.reject(ConnectErrorCodes.didNotFindNetwork.toString(), "Network not found or network request cannot be fulfilled.");
+            }
 
+            @Override
+            public void onLost(@NonNull Network network) {
+                super.onLost(network);
+                DisconnectCallbackHolder.getInstance().unbindProcessFromNetwork();
+                DisconnectCallbackHolder.getInstance().disconnect();
             }
         };
 

--- a/example/with-expo/components/ConnectToSSID.tsx
+++ b/example/with-expo/components/ConnectToSSID.tsx
@@ -14,7 +14,7 @@ export const ConnectToSSID = () => {
     setError('');
     setResponse('');
     setIsLoading(true);
-    WifiManager.connectToProtectedSSID(ssid, pass, false, false)
+    WifiManager.connectToProtectedSSID(ssid, pass, false, false, 10)
       .then((r) => setResponse(JSON.stringify(r, null, 2)))
       .catch((e) => setError(e.toString()))
       .finally(() => setIsLoading(false));

--- a/example/with-expo/components/ConnectToSSID.tsx
+++ b/example/with-expo/components/ConnectToSSID.tsx
@@ -14,7 +14,13 @@ export const ConnectToSSID = () => {
     setError('');
     setResponse('');
     setIsLoading(true);
-    WifiManager.connectToProtectedSSID(ssid, pass, false, false, 10)
+    WifiManager.connectToProtectedWifiSSID({
+      ssid: ssid,
+      password: pass,
+      isWEP: false,
+      isHidden: false,
+      timeout: 10,
+    })
       .then((r) => setResponse(JSON.stringify(r, null, 2)))
       .catch((e) => setError(e.toString()))
       .finally(() => setIsLoading(false));

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -127,6 +127,16 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
     [self connectToProtectedSSIDOnce:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
 }
 
+RCT_EXPORT_METHOD(connectToProtectedWifiSSID:(NSDictionary *)params
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    NSString *ssid = params[@"ssid"];
+    NSString *passphrase = params[@"password"];
+    BOOL isWEP = [params[@"isWEP"] boolValue];
+
+    [self connectToProtectedSSIDOnce:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
+}
+
 RCT_EXPORT_METHOD(connectToProtectedSSIDOnce:(NSString*)ssid
                   withPassphrase:(NSString*)passphrase
                   isWEP:(BOOL)isWEP

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -63,7 +63,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false isHidden:false resolver:resolve rejecter:reject];
+    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false isHidden:false timeout:nil resolver:resolve rejecter:reject];
 }
 
 RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
@@ -121,6 +121,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
                   withPassphrase:(NSString*)passphrase
                   isWEP:(BOOL)isWEP
                   isHidden:(BOOL)isHidden
+                  timeout:(nullable NSNumber *)timeout
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     [self connectToProtectedSSIDOnce:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -96,12 +96,14 @@ declare module 'react-native-wifi-reborn' {
      * @param password `null` for open networks.
      * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
      * @param isHidden only for Android, use if Wi-Fi is hidden.
+     * @param timeout only for Android, timeout in seconds. If the connection is not established in this time, it will reject. Default is 15 seconds.
      */
     export function connectToProtectedSSID(
         SSID: string,
         password: string | null,
         isWEP: boolean,
-        isHidden: boolean
+        isHidden: boolean,
+        timeout: number | null
     ): Promise<void>;
 
     export enum GET_CURRENT_WIFI_SSID_ERRRORS {

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -115,7 +115,7 @@ declare module 'react-native-wifi-reborn' {
      */
     type ConnectToProtectedSSIDParams = {
         ssid: string;
-        password: string;
+        password: string | null;
         isWEP?: boolean;
         isHidden?: boolean;
         timeout?: number;

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -96,14 +96,32 @@ declare module 'react-native-wifi-reborn' {
      * @param password `null` for open networks.
      * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
      * @param isHidden only for Android, use if Wi-Fi is hidden.
-     * @param timeout only for Android, timeout in seconds. If the connection is not established in this time, it will reject. Default is 15 seconds.
      */
     export function connectToProtectedSSID(
         SSID: string,
         password: string | null,
         isWEP: boolean,
-        isHidden: boolean,
-        timeout: number | null
+        isHidden: boolean
+    ): Promise<void>;
+
+    /**
+     * Connects to a WiFi network. Rejects with an error if it couldn't connect.
+     *
+     * @param SSID Wifi name.
+     * @param password `null` for open networks.
+     * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
+     * @param isHidden only for Android, use if Wi-Fi is hidden.
+     * @param timeout only for Android, timeout in seconds. If the connection is not established in this time, it will reject. Default is 15 seconds.
+     */
+    type ConnectToProtectedSSIDParams = {
+        ssid: string;
+        password: string;
+        isWEP?: boolean;
+        isHidden?: boolean;
+        timeout?: number;
+    };
+    export function connectToProtectedWifiSSID(
+        options: ConnectToProtectedSSIDParams
     ): Promise<void>;
 
     export enum GET_CURRENT_WIFI_SSID_ERRRORS {


### PR DESCRIPTION
In this PR, a timeout parameter has been added to the connectToProtectedWifiSSID method.
The parameter, as methods are made today, is mandatory. If set to null then by default it will use a 15 second timeout for the connection. The parameter is to be used in seconds and not in milliseconds, the conversion is done in the method.
The timeout was added only for Android, as I didn't encounter any problems on IOS.
This PR was created because, when we try to connect to a network by entering an incorrect password, the ANDROID system takes too long to return a response.