### PR TITLE
Add connectToProtectedSSIDPrefixOnce method for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.10.2](https://github.com/JuanSeBestia/react-native-wifi-reborn/compare/v4.10.0...v4.10.1) (2024-02-07)
+
+### Features
+
+* **iOS:** 🌟 Add connectToProtectedSSIDPrefixOnce method
+
 ## [4.10.1](https://github.com/JuanSeBestia/react-native-wifi-reborn/compare/v4.10.0...v4.10.1) (2023-11-06)
 
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ The following methods work only on iOS
 
 ### `connectToProtectedSSIDPrefix(SSIDPrefix: string, password: string, isWep: boolean): Promise`
 
+### `connectToProtectedSSIDPrefixOnce(SSIDPrefix: string, password: string, isWep: boolean, joinOnce: boolean): Promise`
+
 Use this function when you want to match a known SSID prefix, but don’t have a full SSID. If the system finds multiple Wi-Fi networks whose SSID string matches the given prefix, it selects the network with the greatest signal strength.
 
 #### SSIDPrefix

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -87,15 +87,25 @@ RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
      }
  }
 
-RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
+RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssidPrefix
                   withPassphrase:(NSString*)passphrase
                   isWEP:(BOOL)isWEP
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
 
+    [self connectToProtectedSSIDPrefixOnce:ssidPrefix withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(connectToProtectedSSIDPrefixOnce:(NSString*)ssidPrefix
+                  withPassphrase:(NSString*)passphrase
+                  isWEP:(BOOL)isWEP
+                  joinOnce:(BOOL)joinOnce
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+
     if (@available(iOS 13.0, *)) {
-        NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssid passphrase:passphrase isWEP:isWEP];
-        configuration.joinOnce = false;
+        NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSIDPrefix:ssidPrefix passphrase:passphrase isWEP:isWEP];
+        configuration.joinOnce = joinOnce;
 
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             if (error != nil) {
@@ -103,10 +113,10 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDPrefix:(NSString*)ssid
             } else {
                 // Verify SSID connection
                 [self getWifiSSID:^(NSString* result) {
-                    if ([result hasPrefix:ssid]){
+                    if ([result hasPrefix:ssidPrefix]){
                         resolve(nil);
                     } else {
-                        reject([ConnectError code:UnableToConnect], [NSString stringWithFormat:@"%@/%@", @"Unable to connect to Wi-Fi with prefix ", ssid], nil);
+                        reject([ConnectError code:UnableToConnect], [NSString stringWithFormat:@"%@/%@", @"Unable to connect to Wi-Fi with prefix ", ssidPrefix], nil);
                     }
                 }];
             }

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -137,6 +137,20 @@ declare module 'react-native-wifi-reborn' {
         password: string,
         isWEP: boolean
     ): Promise<void>;
+    /**
+     * Connects to a WiFi network that start with SSIDPrefix. Rejects with an error if it couldn't connect.
+     *
+     * @param SSIDPrefix Wifi name prefix.
+     * @param password `null` for open networks.
+     * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
+     * @param joinOnce Used on iOS. If `true`, restricts the lifetime of a configuration to the operating status of the app that created it.
+     */
+    export function connectToProtectedSSIDPrefixOnce(
+        SSIDPrefix: string,
+        password: string | null,
+        isWEP: boolean,
+        joinOnce: boolean
+    ): Promise<void>;
 
     //#endregion
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-wifi-reborn",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "A react-native implementation for viewing and connecting to Wifi networks on Android and iOS devices.",
   "types": "lib/types/index.d.ts",
   "main": "src/index.js",


### PR DESCRIPTION
Add new method for iOS
to connect to a SSIDPrefix protected only once