### PR TITLE
fix: crash on Android when isHidden params not passed

### DIFF
--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -262,7 +262,7 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
 
         String ssid = options.getString("ssid");
         String password = options.getString("password");
-        boolean isHidden = options.getBoolean("isHidden");
+        boolean isHidden = options.hasKey("isHidden") && options.getBoolean("isHidden");
         int secondsTimeout = options.hasKey("timeout") ? options.getInt("timeout") * 1000 : TIMEOUT_MILLIS;
 
 


### PR DESCRIPTION
Hi,

with the last release I forgot to add a check on the isHidden parameter.
this generates a crash if it is not passed.
I created this PR to solve the problem immediately.


@JuanSeBestia @gustavoabel 
Thank you