### PR TITLE
docs: fix unclear wifi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ This project is based on the no longer maintained https://github.com/robwalkerco
 
 ### iOS
 
-You need use enable `Access WIFI Information`, with correct profile. `Hotspot Configuration` is required in order to connect to networks.
+Beforehand in XCode, you need use enable `Access WIFI Information` in project settings - '+ Capability'
+![image](https://github.com/user-attachments/assets/4014a442-a7bc-42a6-ba52-f7d241e3e45c)
+![image](https://github.com/user-attachments/assets/c064f8a4-267d-4a46-b62b-a4827bcfbaf8)
+`Hotspot Configuration` is also required in order to connect to networks.
+
+**Please make sure your profile support these two capabilities above.**
 
 #### iOS 13
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This project is based on the no longer maintained https://github.com/robwalkerco
 Beforehand in XCode, you need use enable `Access WIFI Information` in project settings - '+ Capability'
 ![image](https://github.com/user-attachments/assets/4014a442-a7bc-42a6-ba52-f7d241e3e45c)
 ![image](https://github.com/user-attachments/assets/c064f8a4-267d-4a46-b62b-a4827bcfbaf8)
+
 `Hotspot Configuration` is also required in order to connect to networks.
 
 **Please make sure your profile support these two capabilities above.**

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This project is based on the no longer maintained https://github.com/robwalkerco
 ### iOS
 
 Beforehand in XCode, you need use enable `Access WIFI Information` to access Wi-Fi information in project settings - '+ Capability'
+
 ![image](https://github.com/user-attachments/assets/4014a442-a7bc-42a6-ba52-f7d241e3e45c)
 
 `Hotspot Configuration` is also required in order to connect to networks.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ This project is based on the no longer maintained https://github.com/robwalkerco
 
 ### iOS
 
-Beforehand in XCode, you need use enable `Access WIFI Information` in project settings - '+ Capability'
+Beforehand in XCode, you need use enable `Access WIFI Information` to access Wi-Fi information in project settings - '+ Capability'
 ![image](https://github.com/user-attachments/assets/4014a442-a7bc-42a6-ba52-f7d241e3e45c)
-![image](https://github.com/user-attachments/assets/c064f8a4-267d-4a46-b62b-a4827bcfbaf8)
 
 `Hotspot Configuration` is also required in order to connect to networks.
+![image](https://github.com/user-attachments/assets/c064f8a4-267d-4a46-b62b-a4827bcfbaf8)
 
 **Please make sure your profile support these two capabilities above.**
 


### PR DESCRIPTION
The current section for iOS setup makes a lot of people encounter problems when they received error on cannot detect SSID or failed to connect to Wi-Fi, this fix should able to make it more clear for iOS XCode setup.

Image credits to @eliottparis on #385