### PR TITLE
fix(iOS): `connectToProtectedSSID` hangs indefinitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The plugin provides props for extra customization. Every time you change the pro
 ```javascript
 import WifiManager from "react-native-wifi-reborn";
 
-WifiManager.connectToProtectedWifiSSID(ssid, password, isWep).then(
+WifiManager.connectToProtectedWifiSSID({ ssid, password, isWep }).then(
   () => {
     console.log("Connected successfully!");
   },
@@ -178,7 +178,7 @@ _The api documentation is in progress._
 
 The following methods work on both Android and iOS
 
-### `connectToProtectedSSID(SSID: string, password: string, isWEP: boolean, isHidden: boolean, timeout: number): Promise`
+### `connectToProtectedWifiSSID({ SSID: string, password: string, isWEP?: boolean, isHidden?: boolean, timeout?: number }): Promise`
 
 Returns a promise that resolves when connected or rejects with the error when it couldn't connect to the wifi network.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Used on iOS. If true, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 pe
 Type: `boolean`
 Used on Android. If true, the network is a hidden Wi-Fi network.
 
-#### timeout - ```ONLY NEW VERSION```
+#### timeout
 Type: `number`
 Used on Android to set a timeout in seconds. Default 15 seconds.
 

--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -228,35 +228,6 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
         this.context.startActivity(intent);
     }
 
-
-    /**
-     * Use this to connect with a wifi network.
-     * Example:  wifi.findAndConnect(ssid, password, false);
-     * The promise will resolve with the message 'connected' when the user is connected on Android.
-     *
-     * @param SSID     name of the network to connect with
-     * @param password password of the network to connect with
-     * @param isWep    only for iOS
-     * @param isHidden only for Android, use if WiFi is hidden
-     * @param promise  to send success/error feedback
-     */
-    @ReactMethod
-    public void connectToProtectedSSID(@NonNull final String SSID, @NonNull final String password, final boolean isWep, final boolean isHidden, final Promise promise) {
-        if(!assertLocationPermissionGranted(promise)){
-            return;
-        }
-
-        if (!wifi.isWifiEnabled() && !wifi.setWifiEnabled(true)) {
-            promise.reject(ConnectErrorCodes.couldNotEnableWifi.toString(), "On Android 10, the user has to enable wifi manually.");
-            return;
-        }
-
-        this.removeWifiNetwork(SSID, promise, () -> {
-            connectToWifiDirectly(SSID, password, isHidden, TIMEOUT_MILLIS, promise);
-        }, TIMEOUT_REMOVE_MILLIS);
-    }
-
-
     /**
      * Use this to connect with a wifi network.
      * Example:  wifi.findAndConnect(ssid, password, false);

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -63,8 +63,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    NSNumber *defaultTimeout = @(0); // Provide a default value for timeout, fix issue #379
-    [self connectToProtectedSSID:ssid withPassphrase:@"" isWEP:false isHidden:false timeout:defaultTimeout resolver:resolve rejecter:reject];
+    [self connectToProtectedSSIDOnce:ssid withPassphrase:@"" isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
 }
 
 RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid
@@ -128,16 +127,6 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDPrefixOnce:(NSString*)ssidPrefix
     }
 }
 
-RCT_EXPORT_METHOD(connectToProtectedSSID:(NSString*)ssid
-                  withPassphrase:(NSString*)passphrase
-                  isWEP:(BOOL)isWEP
-                  isHidden:(BOOL)isHidden
-                  timeout:(nonnull NSNumber *)timeout // Explicitly mark timeout as nonnull, fix issue #379
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-    [self connectToProtectedSSIDOnce:ssid withPassphrase:passphrase isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
-}
-
 RCT_EXPORT_METHOD(connectToProtectedWifiSSID:(NSDictionary *)params
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
@@ -160,7 +149,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDOnce:(NSString*)ssid
             resolve(nil);
             return;
         }
-        
+
         if (@available(iOS 11.0, *)) {
             NEHotspotConfiguration* configuration;
             // Check if open network
@@ -182,7 +171,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDOnce:(NSString*)ssid
                     __block int tries = 0;
                     __block int maxTries = 20;
                     double intervalSeconds = 0.5;
-                    
+
                     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
                     dispatch_source_t dispatchSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
                     dispatch_time_t startTime = dispatch_time(DISPATCH_TIME_NOW, 0);
@@ -192,7 +181,7 @@ RCT_EXPORT_METHOD(connectToProtectedSSIDOnce:(NSString*)ssid
                         [self getWifiSSID:^(NSString* newSSID) {
                             bool success = [ssid isEqualToString:newSSID];
                             tries++;
-                            
+
                             if (success){
                                 resolve(nil);
                                 dispatch_suspend(dispatchSource);
@@ -286,11 +275,11 @@ RCT_REMAP_METHOD(getCurrentWifiSSID,
 
 - (NSString *)parseError:(NSError *)error {
     if (@available(iOS 11, *)) {
-        
+
         if (!error) {
             return [ConnectError code:UnableToConnect];
         };
-        
+
         /*
          NEHotspotConfigurationErrorInvalid                         = 0,
          NEHotspotConfigurationErrorInvalidSSID                     = 1,

--- a/ios/RNWifi.m
+++ b/ios/RNWifi.m
@@ -63,7 +63,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(connectToSSID:(NSString*)ssid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    [self connectToProtectedSSIDOnce:ssid withPassphrase:@"" isWEP:isWEP joinOnce:false resolver:resolve rejecter:reject];
+    [self connectToProtectedSSIDOnce:ssid withPassphrase:@"" isWEP:false joinOnce:false resolver:resolve rejecter:reject];
 }
 
 RCT_EXPORT_METHOD(connectToSSIDPrefix:(NSString*)ssid

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -97,21 +97,6 @@ declare module 'react-native-wifi-reborn' {
     }
 
     /**
-     * Connects to a WiFi network. Rejects with an error if it couldn't connect.
-     *
-     * @param SSID Wifi name.
-     * @param password `null` for open networks.
-     * @param isWep Used on iOS. If `true`, the network is WEP Wi-Fi; otherwise it is a WPA or WPA2 personal Wi-Fi network.
-     * @param isHidden only for Android, use if Wi-Fi is hidden.
-     */
-    export function connectToProtectedSSID(
-        SSID: string,
-        password: string | null,
-        isWEP: boolean,
-        isHidden: boolean
-    ): Promise<void>;
-
-    /**
      * Suggests a list of Wi-Fi networks on Android. Resolves with 'connected' when the suggestions are added successfully.
      * Only works for Android and requires a minimum SDK version of 29.
      *


### PR DESCRIPTION
https://github.com/JuanSeBestia/react-native-wifi-reborn/pull/397/files?w=1 attempted a fix for https://github.com/JuanSeBestia/react-native-wifi-reborn/issues/379. This PR marks the `timeout` parameter as `nonnull` so the red alert box no longer shows. The PR fails to change the TS types to reflect the nonnull-ness of the timeout parameter, so if you don't pass a timeout, RN doesn't like it and won't call the native method. However, if you look closely this `timeout` parameter isn't used by both iOS and Android, so it seems the right change here is to remove it. 

That said, the root cause of this is us getting confused by having 2 methods `connectToProtectedWifiSSID` and `connectToProtectedSSID` doing the same thing with the sole difference being whether the parameter is in the form of an object or not. This led me to thinking maybe we should just keep one of them, and this is what this PR does.