### PR TITLE
Tweak README.md example - consistently use connectToProtectedSSID

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The plugin provides props for extra customization. Every time you change the pro
 ```javascript
 import WifiManager from "react-native-wifi-reborn";
 
-WifiManager.connectToProtectedWifiSSID(ssid, password, isWep).then(
+WifiManager.connectToProtectedSSID(ssid, password, isWep).then(
   () => {
     console.log("Connected successfully!");
   },


### PR DESCRIPTION
There's a mildly confusing mention of `connectToProtectedWifiSSID` in the README docs, while otherwise only mentioning `connectToProtectedSSID`. This PR clears it up. Both seem to exist in the actual code, and support the same arguments, but I think being consistent would be better?