### PR TITLE
fix(android): connection status support for per-app wifi connections

### DIFF
--- a/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
+++ b/android/src/main/java/com/reactlibrary/rnwifi/RNWifiModule.java
@@ -356,9 +356,22 @@ public class RNWifiModule extends ReactContextBaseJavaModule {
 
     private boolean getConnectionStatus() {
         final ConnectivityManager connectivityManager = (ConnectivityManager) getReactApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+
         if (connectivityManager == null) {
             return false;
         }
+        /**
+         * Check if there's an existing per-app connection, otherwise check the "main" WiFi state
+         */
+        if (isAndroidTenOrLater() && joinedNetwork != null) {
+            NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(joinedNetwork);
+            boolean hasWifiTransport = capabilities != null && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
+            boolean isNetworkAvailable = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED) &&
+                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED);
+
+            return hasWifiTransport && isNetworkAvailable;
+        }
+
         NetworkInfo wifiInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
         if (wifiInfo == null) {
             return false;


### PR DESCRIPTION
This fixes an issue where connections to IoT devices (and probably other regular networks too) would fail because `pollForValidSSID()` was using incorrect connection status checking method for per-app connections.

This issue occurs because `getConnectionStatus` checks only the status of the "main" WiFi state. When connected via a "per-app" connection, calling `getState` within `getConnectionStatus` returns `DISCONNECTED`, and `wifiInfo.isConnected()` returns `false`. However, this doesn't reflect the actual situation, as the established connection is functioning correctly.

## Changes
Modified `getConnectionStatus()` to properly handle per-app WiFi connections on Android 10+ by:
- Using `joinedNetwork` reference for checking connection instead of "main" WiFi
- Adding proper checks to ensure network is available

Let me know if that's a correct implementation and anything can be adjusted.

Fixes #419